### PR TITLE
Update remappings for `foundry-huff-neo` lib

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -9,5 +9,5 @@ ffi = true
 fuzz_runs = 1_000
 remappings = [
   "forge-std=lib/forge-std/src/",
-  "foundry-huff=lib/foundry-huff/src/",
+  "foundry-huff-neo=lib/foundry-huff-neo/src/",
 ]


### PR DESCRIPTION
This pull request updates the remappings in `foundry.toml` to match the `foundry-huff-neo` library.